### PR TITLE
Do not complete message

### DIFF
--- a/src/NServiceBus.AwsLambda.SQS.AcceptanceTests/AwsLambdaSQSEndpointTestBase.cs
+++ b/src/NServiceBus.AwsLambda.SQS.AcceptanceTests/AwsLambdaSQSEndpointTestBase.cs
@@ -24,7 +24,7 @@
 
         protected string BucketName { get; } = Environment.GetEnvironmentVariable("NServiceBus_AmazonSQS_S3Bucket");
         protected string KeyPrefix { get; set; }
-        
+
 
         [SetUp]
         public async Task Setup()

--- a/src/NServiceBus.AwsLambda.SQS.AcceptanceTests/AwsLambdaSQSEndpointTestBase.cs
+++ b/src/NServiceBus.AwsLambda.SQS.AcceptanceTests/AwsLambdaSQSEndpointTestBase.cs
@@ -12,7 +12,6 @@
     using Amazon.SQS;
     using Amazon.SQS.Model;
     using NUnit.Framework;
-    using SQS.AcceptanceTests;
 
     [TestFixture]
     class AwsLambdaSQSEndpointTestBase

--- a/src/NServiceBus.AwsLambda.SQS.AcceptanceTests/MessageExtensions.cs
+++ b/src/NServiceBus.AwsLambda.SQS.AcceptanceTests/MessageExtensions.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.AwsLambda.SQS.AcceptanceTests
+﻿namespace NServiceBus.AwsLambda.Tests
 {
     using System.Linq;
     using Amazon.Lambda.SQSEvents;

--- a/src/NServiceBus.AwsLambda.SQS.AcceptanceTests/ReceiveMessageResponseExtensions.cs
+++ b/src/NServiceBus.AwsLambda.SQS.AcceptanceTests/ReceiveMessageResponseExtensions.cs
@@ -1,4 +1,4 @@
-﻿namespace NServiceBus.AwsLambda.SQS.AcceptanceTests
+﻿namespace NServiceBus.AwsLambda.Tests
 {
     using System.Collections.Generic;
     using Amazon.Lambda.SQSEvents;

--- a/src/NServiceBus.AwsLambda.SQS.AcceptanceTests/When_a_SQSEvent_with_large_payloads_is_processed.cs
+++ b/src/NServiceBus.AwsLambda.SQS.AcceptanceTests/When_a_SQSEvent_with_large_payloads_is_processed.cs
@@ -18,7 +18,7 @@
                 var configuration = new SQSTriggeredEndpointConfiguration(QueueName);
                 var transport = configuration.Transport;
                 transport.ClientFactory(CreateSQSClient);
-                
+
                 var s3 = transport.S3(BucketName, KeyPrefix);
                 s3.ClientFactory(CreateS3Client);
 

--- a/src/NServiceBus.AwsLambda.SQS.AcceptanceTests/When_a_handler_sends_a_message.cs
+++ b/src/NServiceBus.AwsLambda.SQS.AcceptanceTests/When_a_handler_sends_a_message.cs
@@ -14,7 +14,7 @@
 
             var destinationEndpointName = $"{QueueNamePrefix}DestinationEndpoint";
             RegisterQueueNameToCleanup(destinationEndpointName);
-            
+
             var destinationConfiguration = new EndpointConfiguration(destinationEndpointName);
             destinationConfiguration.UsePersistence<InMemoryPersistence>();
             var destinationTransport = destinationConfiguration.UseTransport<SqsTransport>();
@@ -29,10 +29,10 @@
                 var configuration = new SQSTriggeredEndpointConfiguration(QueueName);
                 var transport = configuration.Transport;
                 transport.ClientFactory(CreateSQSClient);
-                
+
                 var routing = transport.Routing();
                 routing.RouteToEndpoint(typeof(SentMessage), destinationEndpointName);
-                
+
                 var advanced = configuration.AdvancedConfiguration;
                 advanced.SendFailedMessagesTo(ErrorQueueName);
                 advanced.RegisterComponents(c => c.RegisterSingleton(typeof(TestContext), context));
@@ -58,7 +58,7 @@
         public class MessageThatTriggersASentMessage : ICommand
         {
         }
-        
+
         public class SentMessage : ICommand
         {
         }
@@ -70,7 +70,7 @@
                 return context.Send(new SentMessage());
             }
         }
-        
+
         public class MessageHandlerThatReceivesSentMessage : IHandleMessages<SentMessage>
         {
             public MessageHandlerThatReceivesSentMessage(TestContext context)


### PR DESCRIPTION
Resolves `Amazon.SQS.Model.ReceiptHandleIsInvalidException: The input receipt handle "MessageReceiptHandle" is not a valid receipt handle. ---> Amazon.Runtime.Internal.HttpErrorResponseException: Exception of type 'Amazon.Runtime.Internal.HttpErrorResponseException' was thrown`